### PR TITLE
[PATCH] writing integer value as float value contrary to Line protocol

### DIFF
--- a/lib/influxdb/point_value.rb
+++ b/lib/influxdb/point_value.rb
@@ -48,8 +48,6 @@ module InfluxDB
     def escape_value(value)
       if value.is_a?(String)
         '"' + escape(value, :field_value) + '"'
-      elsif value.is_a?(Integer)
-        "#{value}i"
       else
         value.to_s
       end

--- a/spec/influxdb/cases/udp_client_spec.rb
+++ b/spec/influxdb/cases/udp_client_spec.rb
@@ -6,7 +6,7 @@ describe InfluxDB::Client do
   specify { expect(client.writer).to be_a(InfluxDB::Writer::UDP) }
 
   describe "#write" do
-    let(:message) { 'responses,region=eu value=5i' }
+    let(:message) { 'responses,region=eu value=5' }
 
     it "sends a UPD packet" do
       s = UDPSocket.new

--- a/spec/influxdb/point_value_spec.rb
+++ b/spec/influxdb/point_value_spec.rb
@@ -13,7 +13,7 @@ describe InfluxDB::PointValue do
     it 'should escape correctly' do
       point = InfluxDB::PointValue.new(data)
       expected = %(1=\\ \\,"\\1,2\\=\\ \\,"\\2=3\\=\\ \\,"\\3 ) +
-                 %(4\\=\\ \\,\\"\\4="5= ,\\"\\5",intval=5i,floatval=7.0)
+                 %(4\\=\\ \\,\\"\\4="5= ,\\"\\5",intval=5,floatval=7.0)
       expect(point.dump).to eq(expected)
     end
   end
@@ -21,7 +21,7 @@ describe InfluxDB::PointValue do
   describe 'dump' do
     context "with all possible data passed" do
       let(:expected_value) do
-        'responses,region=eu,status=200 value=5i,threshold=0.54 1436349652'
+        'responses,region=eu,status=200 value=5,threshold=0.54 1436349652'
       end
       it 'should have proper form' do
         point = InfluxDB::PointValue.new(series: "responses",
@@ -35,7 +35,7 @@ describe InfluxDB::PointValue do
 
     context "with no tags" do
       let(:expected_value) do
-        "responses value=5i,threshold=0.54 1436349652"
+        "responses value=5,threshold=0.54 1436349652"
       end
       it 'should have proper form' do
         point = InfluxDB::PointValue.new(series: "responses",
@@ -48,7 +48,7 @@ describe InfluxDB::PointValue do
 
     context "with values only" do
       let(:expected_value) do
-        "responses value=5i,threshold=0.54"
+        "responses value=5,threshold=0.54"
       end
       it 'should have proper form' do
         point = InfluxDB::PointValue.new(series: "responses",
@@ -60,7 +60,7 @@ describe InfluxDB::PointValue do
 
     context "empty tag values" do
       let(:expected_value) do
-        "responses,region=eu value=5i"
+        "responses,region=eu value=5"
       end
 
       it "should be omitted" do


### PR DESCRIPTION
I cannot apply https://github.com/influxdata/influxdb-ruby/pull/131 to my environment, because I used influxdb-ruby 0.2.3 and had already written Integer value as Float value to my database.

Since CAST method will not be supported (https://github.com/influxdata/influxdb/issues/2911 , https://groups.google.com/forum/#!topic/influxdb/sfKrB2YMPsw), I need to write Integer value as Float value contrary to Line protocol.
